### PR TITLE
[bt#16730] Fixed: When on a mobile phone opening expenses caused a JS crash related to the expand button

### DIFF
--- a/web_groupby_expand/static/src/js/web_groups_expand.js
+++ b/web_groupby_expand/static/src/js/web_groups_expand.js
@@ -58,11 +58,9 @@ AbstractController.include({
         var res = this._super();
         var self = this;
         var totalViews = _.filter(self.actionViews, {multiRecord: self.isMultiRecord});
-        if (totalViews.length <= 1 ) {
+        if (config.device.isMobile) {
             var template = 'ControlPanel.SingleViewSwitchButtons';
-            res = $(QWeb.render(template, {
-                this:self
-            }));
+            res = res.add($(QWeb.render(template, {this: self})))
         }
         var oe_list_expand;
         _.each(res, function(rec){


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=helpdesk.ticket&id=16730">[bt#16730] Re: Error accessing MIUS Prod with mobile phone browser (#4533)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>web_groupby_expand</td><td>.js</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->